### PR TITLE
Hey, Guillaume. Please merge this fix to retrieval by search data.

### DIFF
--- a/lib/Audit/DBI.pm
+++ b/lib/Audit/DBI.pm
@@ -649,7 +649,7 @@ sub review ## no critic (Subroutines::ProhibitExcessComplexity)
 		{
 			my $clause = '(name = ' . $dbh->quote( lc( $value->{'name'} ) ) . ')';
 			
-			$clause = "($clause AND (value IN (" . join( ',', map { $dbh->quote( lc( $value ) ) } @{ $value->{'values'} } ) . ')))'
+			$clause = "($clause AND (value IN (" . join( ',', map { $dbh->quote( lc( $_ ) ) } @{ $value->{'values'} } ) . ')))'
 				if defined( $value->{'values'} ) && ( scalar( @{ $value->{'values'} } ) != 0 );
 			
 			$clause = "(NOT $clause)"


### PR DESCRIPTION
...e using review(). The hash was being converted to a string (e.g. 'hash(0x165ce2c0)') and merged into the SQL rather than the list of values within its "values" member.
